### PR TITLE
refactor(notification): Notification service logging and test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tidy proto-auth clean-proto-auth test-pkg
+.PHONY: tidy proto-auth clean-proto-auth test-pkg test-service
 
 
 tidy:
@@ -53,6 +53,20 @@ ifeq ($(OS),Windows_NT)
 	)
 else
 	@find ./pkg -name "go.mod" -exec dirname {} \; | while read dir; do \
+		echo "Testing $$dir"; \
+		(cd "$$dir" && go test -v ./...); \
+	done
+endif
+
+test-service:
+	@echo "Running tests for services..."
+ifeq ($(OS),Windows_NT)
+	@for /d %%d in (apps\*) do @if exist %%d\go.mod ( \
+		echo Testing apps/%%~nxd & \
+		pushd %%d & go mod download & go test -v ./... & popd \
+	)
+else
+	@find ./apps -name "go.mod" -exec dirname {} \; | while read dir; do \
 		echo "Testing $$dir"; \
 		(cd "$$dir" && go test -v ./...); \
 	done

--- a/apps/notification/internal/subscribers/nats.go
+++ b/apps/notification/internal/subscribers/nats.go
@@ -26,7 +26,7 @@ func NewNatsService(client *nats.Conn, emailSender email.Sender) *NatsService {
 func (n *NatsService) InitNatsSubscriber() {
 	_, err := n.client.Subscribe("email.message", n.emailSubscriber)
 	if err != nil {
-		logging.Logger.Error("Failed to subscribe to NATS topic: %v", err)
+		logging.Logger.Errorf("Failed to subscribe to NATS topic: %v", err)
 		return
 	}
 	logging.Logger.Debug("NATS subscriber initialized successfully")
@@ -37,7 +37,7 @@ func (n *NatsService) emailSubscriber(msg *nats.Msg) {
 	logging.Logger.Debug("Received email message request")
 	var natsEmailMessage natspb.EmailMessage
 	if err := proto.Unmarshal(msg.Data, &natsEmailMessage); err != nil {
-		logging.Logger.Error("Failed to unmarshal email message: %v", err)
+		logging.Logger.Errorf("Failed to unmarshal email message: %v", err)
 		return
 	}
 	logging.Logger.Debugf("Unmarshalled email message, to: %s", natsEmailMessage.To[0:10])
@@ -47,7 +47,7 @@ func (n *NatsService) emailSubscriber(msg *nats.Msg) {
 		Message: natsEmailMessage.Message,
 	}
 	if err := n.emailSender.Send(emailMsg); err != nil {
-		logging.Logger.Error("Failed to send email: %v", err)
+		logging.Logger.Errorf("Failed to send email: %v", err)
 		return
 	}
 	logging.Logger.Infof("Email sent successfully to: %s", natsEmailMessage.To[0:10])


### PR DESCRIPTION
## What's done
- fix(notification): Changed `Logger.Error` to `Logger.Errorf` for better error formatting and test run error fix
- chore: Added `make test-service` command to Makefile for easier service testing

## Why is this important
- Using `Logger.Errorf` provides better error message formatting capabilities
- Fixed test runner error
- The new Makefile command simplifies testing workflow for service development
